### PR TITLE
Remove files from distribution

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -15,3 +15,4 @@
 ^Net-Cisco-MSE-REST.*
 
 debian
+.travis.yml

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -13,3 +13,5 @@
 \.swp
 
 ^Net-Cisco-MSE-REST.*
+
+debian


### PR DESCRIPTION
Arguably the debian folder and .travis.yml file should not be included in distribution tarball.

https://wiki.debian.org/DebianMentorsFaq#What.27s_wrong_with_upstream_shipping_a_debian.2F_directory.3F

Although possibly this is less of an issue than it used to be with the 3.0 debian package format?